### PR TITLE
Feat/especialidade crud mongo

### DIFF
--- a/src/main/java/sistema_clinica/config/DatabaseInitializer.java
+++ b/src/main/java/sistema_clinica/config/DatabaseInitializer.java
@@ -76,6 +76,8 @@ public class DatabaseInitializer implements CommandLineRunner {
         medico.setTelefone("79999990002");
         medico.setTipoUsuario(TipoUsuario.MEDICO);
 
+
+
         List<Usuario> usuarios = Arrays.asList(admin, medico);
         usuarioRepository.saveAll(usuarios);
     }

--- a/src/main/java/sistema_clinica/config/MongoDatabaseInitializer.java
+++ b/src/main/java/sistema_clinica/config/MongoDatabaseInitializer.java
@@ -1,33 +1,43 @@
 package sistema_clinica.config;
 
-
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import sistema_clinica.model.TipoUsuario;
+import sistema_clinica.model.mongo.EspecialidadeDocument;
 import sistema_clinica.model.mongo.UsuarioDocument;
+import sistema_clinica.repository.mongo.EspecialidadeMongoRepository;
 import sistema_clinica.repository.mongo.UsuarioMongoRepository;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 public class MongoDatabaseInitializer implements CommandLineRunner {
 
     private final UsuarioMongoRepository usuarioMongoRepository;
+    private final EspecialidadeMongoRepository especialidadeMongoRepository;
     private final PasswordEncoder passwordEncoder;
 
-    public MongoDatabaseInitializer(UsuarioMongoRepository usuarioMongoRepository, PasswordEncoder passwordEncoder) {
+    public MongoDatabaseInitializer(UsuarioMongoRepository usuarioMongoRepository,
+                                    EspecialidadeMongoRepository especialidadeMongoRepository,
+                                    PasswordEncoder passwordEncoder) {
         this.usuarioMongoRepository = usuarioMongoRepository;
+        this.especialidadeMongoRepository = especialidadeMongoRepository;
         this.passwordEncoder = passwordEncoder;
     }
 
     @Override
     public void run(String... args) throws Exception {
         usuarioMongoRepository.deleteAll();
+        especialidadeMongoRepository.deleteAll();
 
         System.out.println(">>> Populando banco de dados MongoDB com dados iniciais...");
+
         criarUsuariosIniciais();
+        criarEspecialidadesEAssociarMedico();
+
         System.out.println(">>> Dados iniciais inseridos com sucesso no MongoDB!");
     }
 
@@ -40,27 +50,58 @@ public class MongoDatabaseInitializer implements CommandLineRunner {
         admin.setTipoUsuario(TipoUsuario.ADMIN);
 
         UsuarioDocument medico = new UsuarioDocument();
-        medico.setNome("Dr. Mongo");
-        medico.setUsername("medico_mongo");
-        medico.setEmail("medico@mongo.com");
+        medico.setNome("Dr. Carlos MongoDB");
+        medico.setUsername("carlos.med.mongo");
+        medico.setEmail("carlos.med@mongo.com");
         medico.setSenha(passwordEncoder.encode("mongo123"));
         medico.setTipoUsuario(TipoUsuario.MEDICO);
+        medico.setCrm("12345-SE");
 
+        // NOVO USUÁRIO - PACIENTE
         UsuarioDocument paciente = new UsuarioDocument();
-        paciente.setNome("Paciente MongoDB");
-        paciente.setUsername("paciente_mongo");
-        paciente.setEmail("paciente@mongo.com");
-        paciente.setSenha(passwordEncoder.encode("mongo123"));
+        paciente.setNome("Ana Paciente");
+        paciente.setUsername("ana.paciente");
+        paciente.setEmail("ana.paciente@email.com");
+        paciente.setSenha(passwordEncoder.encode("paciente123"));
         paciente.setTipoUsuario(TipoUsuario.PACIENTE);
 
+        // NOVO USUÁRIO - RECEPCIONISTA
         UsuarioDocument recepcionista = new UsuarioDocument();
-        recepcionista.setNome("Recepcionista MongoDB");
-        recepcionista.setUsername("recepcionista_mongo");
-        recepcionista.setEmail("recepcionista@mongo.com");
-        recepcionista.setSenha(passwordEncoder.encode("mongo123"));
+        recepcionista.setNome("Bruno Recepcionista");
+        recepcionista.setUsername("bruno.recep");
+        recepcionista.setEmail("bruno.recep@clinica.com");
+        recepcionista.setSenha(passwordEncoder.encode("recep123"));
         recepcionista.setTipoUsuario(TipoUsuario.RECEPCIONISTA);
 
+        // Adicionando TODOS os usuários à lista para salvar de uma vez
         List<UsuarioDocument> usuarios = Arrays.asList(admin, medico, paciente, recepcionista);
         usuarioMongoRepository.saveAll(usuarios);
+    }
+
+    private void criarEspecialidadesEAssociarMedico() {
+        EspecialidadeDocument cardiologia = new EspecialidadeDocument();
+        cardiologia.setNome("Cardiologia");
+        cardiologia.setDescricao("Cuida de doenças do coração.");
+        cardiologia.setCodCbo("225125");
+
+        EspecialidadeDocument dermatologia = new EspecialidadeDocument();
+        dermatologia.setNome("Dermatologia");
+        dermatologia.setDescricao("Cuida de doenças da pele.");
+        dermatologia.setCodCbo("225135");
+
+        List<EspecialidadeDocument> especialidadesSalvas = especialidadeMongoRepository.saveAll(Arrays.asList(cardiologia, dermatologia));
+
+        UsuarioDocument medicoCarlos = usuarioMongoRepository.findByUsername("carlos.med.mongo")
+                .orElseThrow(() -> new RuntimeException("Erro: Médico 'carlos.med.mongo' não encontrado."));
+
+        List<String> idsDasEspecialidades = especialidadesSalvas.stream()
+                .map(EspecialidadeDocument::getId)
+                .collect(Collectors.toList());
+
+        medicoCarlos.setEspecialidadeIds(idsDasEspecialidades);
+        usuarioMongoRepository.save(medicoCarlos);
+
+        System.out.println(">>> Médico " + medicoCarlos.getNome() + " associado às especialidades: " +
+                especialidadesSalvas.stream().map(EspecialidadeDocument::getNome).collect(Collectors.joining(", ")));
     }
 }

--- a/src/main/java/sistema_clinica/controller/mongo/EspecialidadeMongoController.java
+++ b/src/main/java/sistema_clinica/controller/mongo/EspecialidadeMongoController.java
@@ -25,7 +25,7 @@ public class EspecialidadeMongoController {
     public ResponseEntity<List<EspecialidadeResponseDTO>> listarEspecialidades() {
         List<EspecialidadeDocument> especialidades = especialidadeMongoService.listarTodas();
         List<EspecialidadeResponseDTO> responseDTOs = especialidades.stream()
-                .map(EspecialidadeResponseDTO::new) // Usando o construtor que criamos!
+                .map(EspecialidadeResponseDTO::new)
                 .collect(Collectors.toList());
         return ResponseEntity.ok(responseDTOs);
     }

--- a/src/main/java/sistema_clinica/controller/mongo/EspecialidadeMongoController.java
+++ b/src/main/java/sistema_clinica/controller/mongo/EspecialidadeMongoController.java
@@ -1,0 +1,65 @@
+package sistema_clinica.controller.mongo;
+
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import sistema_clinica.dto.AdicionarEspecialidadeRequestDTO;
+import sistema_clinica.dto.EspecialidadeRequestDTO;
+import sistema_clinica.dto.EspecialidadeResponseDTO;
+import sistema_clinica.dto.UsuarioResponseDTO;
+import sistema_clinica.model.mongo.EspecialidadeDocument;
+import sistema_clinica.model.mongo.UsuarioDocument;
+import sistema_clinica.service.mongo.EspecialidadeMongoService;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/nosql/especialidades")
+public class EspecialidadeMongoController {
+    private final EspecialidadeMongoService especialidadeMongoService;
+
+    public EspecialidadeMongoController(EspecialidadeMongoService especialidadeMongoService) {
+        this.especialidadeMongoService = especialidadeMongoService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<EspecialidadeResponseDTO>> listarEspecialidades() {
+        List<EspecialidadeDocument> especialidades = especialidadeMongoService.listarTodas();
+        List<EspecialidadeResponseDTO> responseDTOs = especialidades.stream()
+                .map(EspecialidadeResponseDTO::new) // Usando o construtor que criamos!
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(responseDTOs);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<EspecialidadeResponseDTO> buscarEspecialidadePorId(@PathVariable String id) {
+        EspecialidadeDocument especialidade = especialidadeMongoService.buscarPorId(id);
+        EspecialidadeResponseDTO responseDTO = new EspecialidadeResponseDTO(especialidade);
+        return ResponseEntity.ok(responseDTO);
+    }
+
+    @PostMapping
+    public ResponseEntity<EspecialidadeResponseDTO> criarEspecialidade(@Valid @RequestBody EspecialidadeRequestDTO dto) {
+        EspecialidadeDocument especialidadeSalva = especialidadeMongoService.criarEspecialidade(dto);
+        EspecialidadeResponseDTO responseDTO = new EspecialidadeResponseDTO(especialidadeSalva);
+        return new ResponseEntity<>(responseDTO, HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<EspecialidadeResponseDTO> atualizarEspecialidade(@PathVariable String id, @Valid @RequestBody EspecialidadeRequestDTO dto) {
+        EspecialidadeDocument especialidadeAtualizada = especialidadeMongoService.atualizarEspecialidade(id, dto);
+        EspecialidadeResponseDTO responseDTO = new EspecialidadeResponseDTO(especialidadeAtualizada);
+        return ResponseEntity.ok(responseDTO);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deletarEspecialidade(@PathVariable String id) {
+        especialidadeMongoService.deletarEspecialidade(id);
+        return ResponseEntity.noContent().build();
+    }
+
+
+
+}

--- a/src/main/java/sistema_clinica/controller/mongo/EspecialidadeMongoController.java
+++ b/src/main/java/sistema_clinica/controller/mongo/EspecialidadeMongoController.java
@@ -4,12 +4,9 @@ import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import sistema_clinica.dto.AdicionarEspecialidadeRequestDTO;
 import sistema_clinica.dto.EspecialidadeRequestDTO;
 import sistema_clinica.dto.EspecialidadeResponseDTO;
-import sistema_clinica.dto.UsuarioResponseDTO;
 import sistema_clinica.model.mongo.EspecialidadeDocument;
-import sistema_clinica.model.mongo.UsuarioDocument;
 import sistema_clinica.service.mongo.EspecialidadeMongoService;
 
 import java.util.List;

--- a/src/main/java/sistema_clinica/controller/mongo/UsuarioMongoController.java
+++ b/src/main/java/sistema_clinica/controller/mongo/UsuarioMongoController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import sistema_clinica.dto.AdicionarEspecialidadeRequestDTO;
 import sistema_clinica.dto.UsuarioRequestDTO;
 import sistema_clinica.dto.UsuarioResponseDTO;
 import sistema_clinica.model.mongo.UsuarioDocument;
@@ -11,7 +12,6 @@ import sistema_clinica.service.mongo.UsuarioMongoService;
 
 import java.util.List;
 import java.util.stream.Collectors;
-
 
 @RestController
 @RequestMapping("/api/nosql/usuarios")
@@ -57,5 +57,23 @@ public class UsuarioMongoController {
     public ResponseEntity<Void> deletarUsuario(@PathVariable String id) {
         usuarioMongoService.deletarUsuario(id);
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{usuarioId}/especialidades")
+    public ResponseEntity<UsuarioResponseDTO> adicionarEspecialidade(
+            @PathVariable String usuarioId,
+            @Valid @RequestBody AdicionarEspecialidadeRequestDTO dto) {
+
+        UsuarioDocument usuarioAtualizado = usuarioMongoService.adicionarEspecialidade(usuarioId, dto.getEspecialidadeId());
+        return ResponseEntity.ok(new UsuarioResponseDTO(usuarioAtualizado));
+    }
+
+    @DeleteMapping("/{usuarioId}/especialidades/{especialidadeId}")
+    public ResponseEntity<UsuarioResponseDTO> removerEspecialidade(
+            @PathVariable String usuarioId,
+            @PathVariable String especialidadeId) {
+
+        UsuarioDocument usuarioAtualizado = usuarioMongoService.removerEspecialidade(usuarioId, especialidadeId);
+        return ResponseEntity.ok(new UsuarioResponseDTO(usuarioAtualizado));
     }
 }

--- a/src/main/java/sistema_clinica/dto/AdicionarEspecialidadeRequestDTO.java
+++ b/src/main/java/sistema_clinica/dto/AdicionarEspecialidadeRequestDTO.java
@@ -1,0 +1,13 @@
+package sistema_clinica.dto;
+
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class AdicionarEspecialidadeRequestDTO {
+
+    @NotBlank(message = "O ID da especialidade é obrigatório.")
+    private String especialidadeId;
+
+}

--- a/src/main/java/sistema_clinica/dto/EspecialidadeResponseDTO.java
+++ b/src/main/java/sistema_clinica/dto/EspecialidadeResponseDTO.java
@@ -1,9 +1,12 @@
 package sistema_clinica.dto;
 
 import lombok.Data;
+import lombok.NoArgsConstructor;
+import sistema_clinica.model.mongo.EspecialidadeDocument;
 import sistema_clinica.model.relacional.Especialidade;
 
 @Data
+@NoArgsConstructor
 public class EspecialidadeResponseDTO {
     private String id;
     private String descricao;
@@ -15,5 +18,11 @@ public class EspecialidadeResponseDTO {
         this.descricao = especialidade.getDescricao();
         this.nome = especialidade.getNome();
         this.codCbo = especialidade.getCodCbo();
+    }
+    public EspecialidadeResponseDTO(EspecialidadeDocument especialidadeDocument) {
+        this.id = especialidadeDocument.getId();
+        this.descricao = especialidadeDocument.getDescricao();
+        this.nome = especialidadeDocument.getNome();
+        this.codCbo = especialidadeDocument.getCodCbo();
     }
 }

--- a/src/main/java/sistema_clinica/model/mongo/EspecialidadeDocument.java
+++ b/src/main/java/sistema_clinica/model/mongo/EspecialidadeDocument.java
@@ -1,0 +1,22 @@
+package sistema_clinica.model.mongo;
+
+import lombok.Data;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "especialidades")
+@Data
+public class EspecialidadeDocument {
+
+    @Id
+    private String id;
+
+    @Indexed(unique = true)
+    private String nome;
+
+    private String descricao;
+
+    private String codCbo;
+
+}

--- a/src/main/java/sistema_clinica/model/mongo/UsuarioDocument.java
+++ b/src/main/java/sistema_clinica/model/mongo/UsuarioDocument.java
@@ -3,7 +3,11 @@ package sistema_clinica.model.mongo;
 import lombok.Data;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
 import sistema_clinica.model.TipoUsuario;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Data
 @Document(collection = "usuario")
@@ -18,4 +22,9 @@ public class UsuarioDocument {
     private String senha;
     private String telefone;
     private TipoUsuario tipoUsuario;
+
+    private String crm;
+
+    @Field("especialidadeIds") // Mapeia a relação "especializado"
+    private List<String> especialidadeIds = new ArrayList<>();
 }

--- a/src/main/java/sistema_clinica/repository/mongo/EspecialidadeMongoRepository.java
+++ b/src/main/java/sistema_clinica/repository/mongo/EspecialidadeMongoRepository.java
@@ -1,0 +1,10 @@
+package sistema_clinica.repository.mongo;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import sistema_clinica.model.mongo.EspecialidadeDocument;
+
+import java.util.Optional;
+
+public interface EspecialidadeMongoRepository extends MongoRepository<EspecialidadeDocument, String> {
+    Optional<EspecialidadeDocument> findByNome(String nome);
+}

--- a/src/main/java/sistema_clinica/repository/mongo/EspecialidadeMongoRepository.java
+++ b/src/main/java/sistema_clinica/repository/mongo/EspecialidadeMongoRepository.java
@@ -2,9 +2,10 @@ package sistema_clinica.repository.mongo;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
 import sistema_clinica.model.mongo.EspecialidadeDocument;
-
+import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
+@Repository
 public interface EspecialidadeMongoRepository extends MongoRepository<EspecialidadeDocument, String> {
     Optional<EspecialidadeDocument> findByNome(String nome);
 }

--- a/src/main/java/sistema_clinica/repository/mongo/UsuarioMongoRepository.java
+++ b/src/main/java/sistema_clinica/repository/mongo/UsuarioMongoRepository.java
@@ -1,11 +1,16 @@
 package sistema_clinica.repository.mongo;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+import sistema_clinica.model.TipoUsuario;
 import sistema_clinica.model.mongo.UsuarioDocument;
 
+import java.util.List;
 import java.util.Optional;
 
-
+@Repository
 public interface UsuarioMongoRepository extends MongoRepository<UsuarioDocument, String> {
     Optional<UsuarioDocument> findByUsername(String username);
+
+    List<UsuarioDocument> findByTipoUsuarioAndEspecialidadeIdsContains(TipoUsuario tipo, String especialidadeId);
 }

--- a/src/main/java/sistema_clinica/repository/relacional/MedicoRepository.java
+++ b/src/main/java/sistema_clinica/repository/relacional/MedicoRepository.java
@@ -1,11 +1,12 @@
 package sistema_clinica.repository.relacional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 import sistema_clinica.model.relacional.Medico;
 import sistema_clinica.model.relacional.Usuario;
 
 import java.util.Optional;
 
-
+@Repository
 public interface MedicoRepository extends JpaRepository<Medico,Integer> {
 }

--- a/src/main/java/sistema_clinica/repository/relacional/UsuarioRepository.java
+++ b/src/main/java/sistema_clinica/repository/relacional/UsuarioRepository.java
@@ -1,11 +1,12 @@
 package sistema_clinica.repository.relacional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 import sistema_clinica.model.relacional.Usuario;
 
 import java.util.Optional;
 
-
+@Repository
 public interface UsuarioRepository extends JpaRepository<Usuario,Integer> {
     Optional<Usuario> findByUsername(String username);
 }

--- a/src/main/java/sistema_clinica/service/mongo/EspecialidadeMongoService.java
+++ b/src/main/java/sistema_clinica/service/mongo/EspecialidadeMongoService.java
@@ -1,0 +1,65 @@
+package sistema_clinica.service.mongo;
+
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.stereotype.Service;
+import sistema_clinica.dto.EspecialidadeRequestDTO;
+import sistema_clinica.model.mongo.EspecialidadeDocument;
+import sistema_clinica.repository.mongo.EspecialidadeMongoRepository;
+
+
+import java.util.List;
+
+@Service
+public class EspecialidadeMongoService {
+
+    private final EspecialidadeMongoRepository especialidadeMongoRepository;
+
+    public EspecialidadeMongoService(EspecialidadeMongoRepository especialidadeMongoRepository) {
+        this.especialidadeMongoRepository = especialidadeMongoRepository;
+    }
+
+    public List<EspecialidadeDocument> listarTodas() {
+        return especialidadeMongoRepository.findAll();
+    }
+
+    public EspecialidadeDocument buscarPorId(String id) {
+        return especialidadeMongoRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Especialidade com id: " + id + " não encontrada."));
+    }
+
+    public EspecialidadeDocument criarEspecialidade(EspecialidadeRequestDTO dto) {
+        if (especialidadeMongoRepository.findByNome(dto.getNome()).isPresent()) {
+            throw new IllegalArgumentException("Uma especialidade com o nome '" + dto.getNome() + "' já existe.");
+        }
+
+        EspecialidadeDocument novaEspecialidade = new EspecialidadeDocument();
+        novaEspecialidade.setNome(dto.getNome());
+        novaEspecialidade.setDescricao(dto.getDescricao());
+        novaEspecialidade.setCodCbo(dto.getCodCbo());
+
+        return especialidadeMongoRepository.save(novaEspecialidade);
+    }
+
+    public EspecialidadeDocument atualizarEspecialidade(String id, EspecialidadeRequestDTO dto) {
+        EspecialidadeDocument especialidadeExistente = buscarPorId(id);
+
+        especialidadeMongoRepository.findByNome(dto.getNome()).ifPresent(outraEspecialidade -> {
+            if (!outraEspecialidade.getId().equals(id)) {
+                throw new IllegalArgumentException("O nome '" + dto.getNome() + "' já está em uso por outra especialidade.");
+            }
+        });
+
+        especialidadeExistente.setNome(dto.getNome());
+        especialidadeExistente.setDescricao(dto.getDescricao());
+        especialidadeExistente.setCodCbo(dto.getCodCbo());
+
+        return especialidadeMongoRepository.save(especialidadeExistente);
+    }
+
+    public void deletarEspecialidade(String id) {
+        if (!especialidadeMongoRepository.existsById(id)) {
+            throw new EntityNotFoundException("Especialidade com id: " + id + " não encontrada para exclusão.");
+        }
+        especialidadeMongoRepository.deleteById(id);
+    }
+}


### PR DESCRIPTION
Este PR adiciona a funcionalidade completa para gerenciar Usuários e Especialidades no banco de dados MongoDB.

Foram criados os controllers, services, repositories e models necessários para a API, incluindo a lógica para associar especialidades a médicos.

Principais adições:

Endpoints REST em /api/nosql/usuarios e /api/nosql/especialidades.

Lógica de negócio para CRUD e associações nos Services.

MongoDatabaseInitializer para popular o banco com dados de teste.